### PR TITLE
Fixed issue that sometimes caused status block not to get called.

### DIFF
--- a/Classes/Private/SCReachabilityScheduler.h
+++ b/Classes/Private/SCReachabilityScheduler.h
@@ -12,7 +12,6 @@
 
 @interface SCReachabilityScheduler : NSObject
 
-- (id)initWithReachabilityRef:(SCNetworkReachabilityRef)reachabilityRef;
-- (void)observeStatusChanges:(void (^)(SCNetworkStatus status))statusChangesBlock;
+- (id)initWithReachabilityRef:(SCNetworkReachabilityRef)reachabilityRef statusChangesBlock:(void (^)(SCNetworkStatus status))statusChangesBlock;
 
 @end

--- a/Classes/Private/SCReachabilityScheduler.m
+++ b/Classes/Private/SCReachabilityScheduler.m
@@ -24,12 +24,13 @@ static void callbackForReachabilityRef(SCNetworkReachabilityRef target,
 
 #pragma mark - life cycle
 
-- (id)initWithReachabilityRef:(SCNetworkReachabilityRef)reachabilityRef
+- (id)initWithReachabilityRef:(SCNetworkReachabilityRef)reachabilityRef statusChangesBlock:(void (^)(SCNetworkStatus status))statusChangesBlock
 {
     self = [super init];
     if (self)
     {
         _reachabilityRef = reachabilityRef;
+        _statusChangesBlock = statusChangesBlock;
         NSString *name = [NSString stringWithFormat:@"org.okolodev.reachability.%lu",
                           (unsigned long)self.hash];
         _queue = dispatch_queue_create([name UTF8String], NULL);
@@ -55,13 +56,6 @@ static void callbackForReachabilityRef(SCNetworkReachabilityRef target,
         dispatch_release(_queue);
     }
 #endif
-}
-
-#pragma mark - public
-
-- (void)observeStatusChanges:(void (^)(SCNetworkStatus status))statusChangesBlock
-{
-    self.statusChangesBlock = statusChangesBlock;
 }
 
 #pragma mark - callback

--- a/Classes/Public/SCNetworkReachability.m
+++ b/Classes/Public/SCNetworkReachability.m
@@ -38,8 +38,7 @@ NSString *const kReachabilityDefaultHost = @"www.google.com";
 {
     SCNetworkReachabilityRef reachabilityRef;
     reachabilityRef = [SCReachabilityRefBuilder reachabilityRefWithHostName:host];
-    self = [self initWithReachabilityRef:reachabilityRef];
-    if (self)
+    if ([self initWithReachabilityRef:reachabilityRef])
     {
         _host = host;
     }
@@ -51,19 +50,18 @@ NSString *const kReachabilityDefaultHost = @"www.google.com";
     self = [super init];
     if (self)
     {
-        _scheduler = [[SCReachabilityScheduler alloc] initWithReachabilityRef:reachabilityRef];
         __weak __typeof (self) weakSelf = self;
-        [_scheduler observeStatusChanges:^(SCNetworkStatus status)
-        {
-            if (!weakSelf.isStatusValid && weakSelf.statusBlock)
-            {
-                weakSelf.statusBlock(status);
-                weakSelf.statusBlock = nil;
-            }
-            weakSelf.isStatusValid = YES;
-            weakSelf.status = status;
-            weakSelf.observationBlock ? weakSelf.observationBlock(status) : nil;
-        }];
+        _scheduler = [[SCReachabilityScheduler alloc] initWithReachabilityRef:reachabilityRef statusChangesBlock:^(SCNetworkStatus status)
+              {
+                  if (!weakSelf.isStatusValid && weakSelf.statusBlock)
+                  {
+                      weakSelf.statusBlock(status);
+                      weakSelf.statusBlock = nil;
+                  }
+                  weakSelf.isStatusValid = YES;
+                  weakSelf.status = status;
+                  weakSelf.observationBlock ? weakSelf.observationBlock(status) : nil;
+              }];
     }
     return self;
 }


### PR DESCRIPTION
This issue occurred in an app that called SCNetworkReachability.initWithHost:
from application:didFinishLaunchingWithOptions:.
In SCNetworkReachability.initWithReachabilityRef: the method
SCReachabilityScheduler.initWithReachabilityRef: is called before
setting statusChangesBlock with method observeStatusChanges:.
In some cases SCReachabilityScheduler.callbackForReachabilityRef
callback function could get called before observeStatusChanges:
got called -> statusChangesBlock was nil and the callback
got ignored. So the app didn't get notified of the network status
until it changed again. This issue was quite easy to reproduce
with an iPhone4 (7.1.2) with WiFi connection (no SIM card was inserted).

The fix was to pass the statusChangesBlock in the
SCReachabilityScheduler.initWithReachabilityRef method.
