### PR TITLE
Support dynamic frameworks.

### DIFF
--- a/Classes/Subspecs/Shared/SCNetworkReachability+Shared.h
+++ b/Classes/Subspecs/Shared/SCNetworkReachability+Shared.h
@@ -7,7 +7,7 @@
 //
 
 #import "SCNetworkReachability.h"
-#import "ABMultitonProtocol.h"
+#import <ABMultiton/ABMultitonProtocol.h>
 
 @interface SCNetworkReachability (Shared) <ABMultitonProtocol>
 


### PR DESCRIPTION
Fix import to prevent compiler errors when building in a dynamic framework, such as the case when importing the CocoaPod into a Swift project.